### PR TITLE
Update for Ubuntu 22.04.4 LTS and CUDA 12.1 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 # Unique3D
 Official implementation of Unique3D: High-Quality and Efficient 3D Mesh Generation from a Single Image. 
-Adapted for Ubuntu 22.04.4 LTS and CUDA 12.1.
 
 [Kailu Wu](https://scholar.google.com/citations?user=VTU0gysAAAAJ&hl=zh-CN&oi=ao), [Fangfu Liu](https://liuff19.github.io/), Zhihan Cai, Runjie Yan, Hanyang Wang, Yating Hu, [Yueqi Duan](https://duanyueqi.github.io/), [Kaisheng Ma](https://group.iiis.tsinghua.edu.cn/~maks/)
 
@@ -35,6 +34,8 @@ The repo is still being under construction, thanks for your patience.
 ## Preparation for inference
 
 ### Linux System Setup.
+
+Adapted for Ubuntu 22.04.4 LTS and CUDA 12.1.
 ```angular2html
 conda create -n unique3d python=3.11
 conda activate unique3d

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 **中文版本 [中文](README_zh.md)**
 
 # Unique3D
-Official implementation of Unique3D: High-Quality and Efficient 3D Mesh Generation from a Single Image
+Official implementation of Unique3D: High-Quality and Efficient 3D Mesh Generation from a Single Image. 
+Adapted for Ubuntu 22.04.4 LTS and CUDA 12.1.
 
 [Kailu Wu](https://scholar.google.com/citations?user=VTU0gysAAAAJ&hl=zh-CN&oi=ao), [Fangfu Liu](https://liuff19.github.io/), Zhihan Cai, Runjie Yan, Hanyang Wang, Yating Hu, [Yueqi Duan](https://duanyueqi.github.io/), [Kaisheng Ma](https://group.iiis.tsinghua.edu.cn/~maks/)
 
@@ -35,8 +36,14 @@ The repo is still being under construction, thanks for your patience.
 
 ### Linux System Setup.
 ```angular2html
-conda create -n unique3d
+conda create -n unique3d python=3.11
 conda activate unique3d
+
+pip install ninja
+pip install diffusers==0.27.2
+
+pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu121/torch2.3.1/index.html
+
 pip install -r requirements.txt
 ```
 

--- a/custum_3d_diffusion/custum_modules/unifield_processor.py
+++ b/custum_3d_diffusion/custum_modules/unifield_processor.py
@@ -204,6 +204,7 @@ class ConfigurableUNet2DConditionModel(Configurable, IPAdapterMixin):
         
         self.unet: UnifieldWrappedUNet = unet_type.from_pretrained(
             attn_config.init_unet_path, subfolder="unet", torch_dtype=self.weight_dtype, 
+            ignore_mismatched_sizes=True,  # Added this line
             **unet_kwargs
         )
         assert isinstance(self.unet, UnifieldWrappedUNet)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pygltflib
 pymeshlab>=2023.12
 git+https://github.com/facebookresearch/pytorch3d.git@stable
 rembg[gpu]
-torch>=2.0.1
+#torch>=2.0.1
 torch_scatter
 tqdm
 transformers


### PR DESCRIPTION
- Adapted the `Unique3D` project to work on Ubuntu 22.04.4 LTS and CUDA 12.1.
- Updated the README with installation instructions for the new environment.
- Fixed a bug in `custom_3d_diffusion/custom_modules/unifield_processor.py` by adding `ignore_mismatched_sizes=True` in the model configuration.
- Updated dependencies in `requirements.txt`.